### PR TITLE
Setting up .eslintrc

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,0 +1,35 @@
+{
+  "extends": [
+    "eslint:recommended",
+    "plugin:import/errors",
+    "plugin:react/recommended",
+    "plugin:jsx-a11y/recommended",
+    "prettier",
+    "prettier/react",
+    "airbnb",
+    "plugin:@typescript-eslint/eslint-recommended",
+    "plugin:@typescript-eslint/recommended"
+  ],
+  "rules": {
+    "react/prop-types": 0
+  },
+  "parser": "@typescript-eslint/parser",
+  "plugins": ["react", "import", "jsx-a11y","@typescript-eslint"],
+  "parserOptions": {
+    "ecmaVersion": 2019,
+    "sourceType": "module",
+    "ecmaFeatures": {
+      "jsx": true
+    }
+  },
+  "env": {
+    "es6": true,
+    "browser": true,
+    "node": true
+  },
+  "settings": {
+    "react": {
+      "version": "detect"
+    }
+  }
+}


### PR DESCRIPTION
Problem: We need a standard linting configuration file so we're all using the same standards.

Solution: Setting up .eslintrc to use the airbnb standard and be able to parse typescript.